### PR TITLE
Add device and stage selectors

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,18 +6,63 @@ import { Spinner } from "../components/Spinner";
 
 export default function Home() {
   const params = new URLSearchParams(location.hash.replace(/^#/, ""));
-  const device = params.get("device") ?? "flood";
-  const stage = params.get("stage") ?? "staging";
+
+  const DEVICE_TYPES = ["flood", "motion", "implant"] as const;
+  const STAGES = ["staging", "production"] as const;
+
+  const [device, setDevice] = useState<string>(
+    params.get("device") ?? DEVICE_TYPES[0],
+  );
+  const [stage, setStage] = useState<string>(
+    params.get("stage") ?? STAGES[0],
+  );
   const [builds, setBuilds] = useState<Build[] | null>(null);
 
   useEffect(() => {
     fetchBuilds(stage, device).then(setBuilds).catch(() => setBuilds([]));
   }, [stage, device]);
 
+  // Keep hash params in sync with current selection
+  useEffect(() => {
+    const params = new URLSearchParams();
+    params.set("device", device);
+    params.set("stage", stage);
+    location.hash = params.toString();
+  }, [device, stage]);
+
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="text-3xl font-bold">Vemmio Flasher</h1>
-      <p className="mt-2 text-slate-400">Device: {device} | Stage: {stage}</p>
+      <div className="mt-4 flex gap-4">
+        <label className="text-sm">
+          Device:
+          <select
+            className="ml-2 bg-slate-800 border border-slate-700 rounded px-2 py-1"
+            value={device}
+            onChange={(e) => setDevice(e.target.value)}
+          >
+            {DEVICE_TYPES.map((d) => (
+              <option key={d} value={d}>
+                {d}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="text-sm">
+          Stage:
+          <select
+            className="ml-2 bg-slate-800 border border-slate-700 rounded px-2 py-1"
+            value={stage}
+            onChange={(e) => setStage(e.target.value)}
+          >
+            {STAGES.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
       {builds === null ? (
         <div className="flex items-center mt-8 gap-2"><Spinner /> Ładowanie…</div>
       ) : (


### PR DESCRIPTION
## Summary
- make device type and stage options selectable on the Home screen
- sync URL hash with selected options

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b63675a288332b022090774612220