### PR TITLE
Adjust page colors to match flash dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#0f172a" />
+    <meta name="theme-color" content="#ffffff" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <title>Vemmio Flasher</title>
   </head>
-  <body class="bg-slate-950 text-slate-100">
+  <body class="bg-white text-slate-900">
     <noscript>Ta aplikacja wymaga włączonego JavaScript.</noscript>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/src/components/BuildList.tsx
+++ b/src/components/BuildList.tsx
@@ -10,7 +10,7 @@ export default function BuildList({ builds }: Props) {
     return (
         <table className="w-full text-left mt-4">
             <thead>
-            <tr className="border-b border-slate-700">
+            <tr className="border-b border-gray-300">
                 <th className="py-2">Wersja</th>
                 <th className="py-2">Stage</th>
                 <th className="py-2" />
@@ -18,7 +18,7 @@ export default function BuildList({ builds }: Props) {
             </thead>
             <tbody>
             {builds.map((b) => (
-                <tr key={b.version} className="group border-b border-slate-800">
+                <tr key={b.version} className="group border-b border-gray-200">
                     <td className="py-2 font-mono">{b.version}</td>
                     <td className="py-2">{b.stage}</td>
                     <td className="py-2 text-right">

--- a/src/components/DropZone.tsx
+++ b/src/components/DropZone.tsx
@@ -61,7 +61,7 @@ export default function DropZone() {
       <div
           {...getRootProps()}
           className={`mt-8 p-6 border-2 rounded-lg border-dashed ${
-              isDragActive ? "border-indigo-500" : "border-slate-500"
+              isDragActive ? "border-indigo-500" : "border-gray-500"
           }`}
       >
         <input {...getInputProps()} />
@@ -71,7 +71,7 @@ export default function DropZone() {
             <p>Przeciągnij ZIP z firmware lub kliknij by wybrać.</p>
         )}
         {log.length > 0 && (
-            <pre className="mt-4 text-xs max-h-48 overflow-auto">{log.join("\n")}</pre>
+            <pre className="mt-4 text-xs max-h-48 overflow-auto bg-gray-200 p-2 rounded">{log.join("\n")}</pre>
         )}
       </div>
   );

--- a/src/components/FlashDialog.tsx
+++ b/src/components/FlashDialog.tsx
@@ -117,7 +117,7 @@ export function FlashDialog({ build }: Props) {
 
       {open && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-10">
-          <div className="bg-slate-800 p-4 rounded w-96">
+          <div className="bg-white text-slate-900 p-4 rounded w-96">
             <div className="flex justify-between items-center mb-2">
               <h2 className="font-bold">Flash {build.version}</h2>
               <button onClick={closeDialog}>&times;</button>
@@ -136,7 +136,7 @@ export function FlashDialog({ build }: Props) {
             )}
 
             {log.length > 0 && (
-              <pre className="mt-2 p-2 bg-slate-900 text-xs max-h-48 overflow-auto rounded">
+              <pre className="mt-2 p-2 bg-gray-200 text-xs max-h-48 overflow-auto rounded">
                 {log.join("\n")}
               </pre>
             )}

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,3 +1,3 @@
 export const Spinner = () => (
-  <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-slate-200" />
+  <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-indigo-600" />
 );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -37,7 +37,7 @@ export default function Home() {
         <label className="text-sm">
           Device:
           <select
-            className="ml-2 bg-slate-800 border border-slate-700 rounded px-2 py-1"
+            className="ml-2 bg-white border border-gray-300 rounded px-2 py-1"
             value={device}
             onChange={(e) => setDevice(e.target.value)}
           >
@@ -51,7 +51,7 @@ export default function Home() {
         <label className="text-sm">
           Stage:
           <select
-            className="ml-2 bg-slate-800 border border-slate-700 rounded px-2 py-1"
+            className="ml-2 bg-white border border-gray-300 rounded px-2 py-1"
             value={stage}
             onChange={(e) => setStage(e.target.value)}
           >

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -27,14 +27,14 @@ export default function Login() {
     >
       <h1 className="text-2xl font-bold text-center">Logowanie</h1>
       <input
-        className="px-3 py-2 rounded bg-slate-800"
+        className="px-3 py-2 rounded bg-white border border-gray-300"
         placeholder="Użytkownik"
         value={user}
         onChange={(e) => setUser(e.target.value)}
       />
       <input
         type="password"
-        className="px-3 py-2 rounded bg-slate-800"
+        className="px-3 py-2 rounded bg-white border border-gray-300"
         placeholder="Hasło"
         value={pass}
         onChange={(e) => setPass(e.target.value)}


### PR DESCRIPTION
## Summary
- lighten app theme to mirror esp-web-tools dialog
- update table and form colors
- tweak drop zone border and log styling
- keep spinner visible on light background

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b6dcffc688332b679949d1cccef0f