### PR TITLE
Fix login popup triggered by HTTP auth header

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -23,7 +23,6 @@ function json(data: unknown, status = 200): Response {
 function unauthorized(): Response {
   return new Response("Unauthorized", {
     status: 401,
-    headers: { "WWW-Authenticate": "Basic" },
   });
 }
 


### PR DESCRIPTION
## Summary
- remove `WWW-Authenticate` header from 401 responses to stop browser login prompts

## Testing
- `npm test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688c718d1bf08332be0e14ede2e84518