### PR TITLE
Center connect button in flash dialog

### DIFF
--- a/src/components/FlashDialog.tsx
+++ b/src/components/FlashDialog.tsx
@@ -135,8 +135,9 @@ export function FlashDialog({ build }: Props) {
             )}
 
             {phase === "ready" && manifestUrl && (
-              <esp-web-install-button manifest={manifestUrl}>
-                </esp-web-install-button>
+              <div className="flex justify-center">
+                <esp-web-install-button manifest={manifestUrl}></esp-web-install-button>
+              </div>
             )}
 
             {log.length > 0 && (


### PR DESCRIPTION
## Summary
- center the flash dialog's connect button with a flexbox wrapper

## Testing
- `npm test -- --run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68906f3e2f54833289df97909b03367c