### PR TITLE
fix: correct wrangler deploy entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && wrangler deploy worker",
+    "build": "vite build && wrangler deploy",
     "preview": "vite preview",
     "test": "vitest"
   },


### PR DESCRIPTION
## Summary
- deploy worker via wrangler config instead of directory argument

## Testing
- `pnpm vitest run` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6891aa856de8833291e8e475ed8bc5eb