### PR TITLE
feat: add start script for digital ocean app

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Alternatively, use Docker Compose for a one‑step build & run:
 docker-compose up --build
 ```
 
+## DigitalOcean App Platform Deployment
+
+For App Platform deployments use the following commands:
+
+* Build command: `npm run build`
+* Run command: `npm start` (uses `PORT` provided by App Platform)
+
 ## DigitalOcean Functions Deployment
 
 You can deploy the same API logic to DigitalOcean Functions using the `do-worker` folder or the npm script:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "api": "tsx --env-file=.dev.vars local-api.ts",
     "build": "vite build",
     "preview": "vite preview",
+    "start": "vite preview --host 0.0.0.0 --port ${PORT:-8080}",
     "test": "vitest",
     "deploy:do": "cd do-worker && doctl serverless deploy --remote"
   },


### PR DESCRIPTION
## Summary
- add npm start script that runs `vite preview` on the platform's PORT
- document App Platform build and run commands in README

## Testing
- `CI=true npm test` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6894611242b8833283c53c524962f745